### PR TITLE
fix: display loading when children are present 

### DIFF
--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useReducer, useRef } from "react";
-import { Skeleton, Spinner, Button } from "react-ck";
+import { Skeleton } from "../skeleton";
+import { Spinner } from "../spinner";
+import { Button } from "../button";
 
 const DefaultContentWrapper: React.FC<React.PropsWithChildren> = ({ children }) => children;
 

--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -47,8 +47,6 @@ interface InfiniteScrollStatus {
   infiniteScrollEnabled: boolean;
   /** Whether the intersection observer is intersecting */
   isIntersecting: boolean;
-  /** Whether the infinite scroll is idle */
-  isIdle: boolean;
 }
 
 export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProps>> = ({
@@ -71,14 +69,13 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
   const intersectionRef = useRef<HTMLDivElement>(null);
 
   // Status
-  const [{ infiniteScrollEnabled, isIntersecting, isIdle }, setStatus] = useReducer(
+  const [{ infiniteScrollEnabled, isIntersecting }, setStatus] = useReducer(
     (prev: InfiniteScrollStatus, next: Partial<InfiniteScrollStatus>) => {
       return { ...prev, ...next };
     },
     {
       infiniteScrollEnabled: mode === "infinite",
       isIntersecting: false,
-      isIdle: false,
     },
   );
 
@@ -136,28 +133,17 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
       loadingMore ||
       loading ||
       !hasItemsLeft ||
-      isIdle
-    )
+    ) {
       return;
-
-    async function load() {
-      setStatus({ isIdle: true });
-      try {
-        await onLoadMore();
-      } finally {
-        setStatus({ isIdle: false });
-      }
     }
+        void onLoadMore();
 
-    // Load more
-    void load();
   }, [
     hasItemsLeft,
     infiniteScrollEnabled,
     isIntersecting,
     loading,
     loadingMore,
-    isIdle,
     onLoadMore,
   ]);
 

--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -127,25 +127,11 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
 
   // Load more
   useEffect(() => {
-    if (
-      !isIntersecting ||
-      !infiniteScrollEnabled ||
-      loadingMore ||
-      loading ||
-      !hasItemsLeft ||
-    ) {
+    if (!isIntersecting || !infiniteScrollEnabled || loadingMore || loading || !hasItemsLeft) {
       return;
     }
-        void onLoadMore();
-
-  }, [
-    hasItemsLeft,
-    infiniteScrollEnabled,
-    isIntersecting,
-    loading,
-    loadingMore,
-    onLoadMore,
-  ]);
+    void onLoadMore();
+  }, [hasItemsLeft, infiniteScrollEnabled, isIntersecting, loading, loadingMore, onLoadMore]);
 
   // Load more controls
   const LoadMoreControls = useMemo(() => {

--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -83,10 +83,7 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
   );
 
   // Has items left
-  const hasItemsLeft = useMemo(
-    () => (loaded === undefined && total === undefined) || (loaded ?? 0) < (total ?? 0),
-    [loaded, total],
-  );
+  const hasItemsLeft = useMemo(() => (loaded ?? 0) < (total ?? 0), [loaded, total]);
 
   // Load more button
   const LoadMoreButton = useMemo(() => {
@@ -170,11 +167,18 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
       return loadingMoreElement ?? <Spinner />;
     }
 
-    return displayLoadMore && !infiniteScrollEnabled && LoadMoreButton;
-  }, [LoadMoreButton, displayLoadMore, infiniteScrollEnabled, loadingMore, loadingMoreElement]);
+    return displayLoadMore && hasItemsLeft && !infiniteScrollEnabled && LoadMoreButton;
+  }, [
+    LoadMoreButton,
+    displayLoadMore,
+    hasItemsLeft,
+    infiniteScrollEnabled,
+    loadingMore,
+    loadingMoreElement,
+  ]);
 
   // Loading element
-  if (hasItemsLeft && loading) {
+  if (loading) {
     return loadingElement ?? <Skeleton />;
   }
 

--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -130,6 +130,8 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
     if (!isIntersecting || !infiniteScrollEnabled || loadingMore || loading || !hasItemsLeft) {
       return;
     }
+
+    // Load more items
     void onLoadMore();
   }, [hasItemsLeft, infiniteScrollEnabled, isIntersecting, loading, loadingMore, onLoadMore]);
 

--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -80,7 +80,10 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
   );
 
   // Has items left
-  const hasItemsLeft = useMemo(() => (loaded ?? 0) < (total ?? 0), [loaded, total]);
+  const hasItemsLeft = useMemo(
+    () => (loaded === undefined && total === undefined) || (loaded ?? 0) < (total ?? 0),
+    [loaded, total],
+  );
 
   // Load more button
   const LoadMoreButton = useMemo(() => {

--- a/packages/components/base/src/infinite-scroll/index.tsx
+++ b/packages/components/base/src/infinite-scroll/index.tsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Skeleton } from "../skeleton";
-import { Spinner } from "../spinner";
-import { Button } from "../button";
+import React, { useEffect, useMemo, useReducer, useRef } from "react";
+import { Skeleton, Spinner, Button } from "react-ck";
 
-const defaultContentWrapper: React.FC<React.PropsWithChildren> = ({ children }) => <>{children}</>;
+const DefaultContentWrapper: React.FC<React.PropsWithChildren> = ({ children }) => children;
 
 /**
  * Props for the InfiniteScroll component that handles automatic loading of content
  * as the user scrolls or clicks a load more button.
  */
 export interface InfiniteScrollProps {
-  /** Direction of infinite scroll - adapts the behaviour according to the scroll direction */
+  /**
+   * Direction of infinite scroll - adapts the behaviour according to the scroll direction
+   * @default "bottom"
+   */
   direction?: "bottom" | "top";
   /** Number of items currently loaded - used to determine if more items are available */
   loaded?: number;
@@ -24,17 +25,30 @@ export interface InfiniteScrollProps {
   loadingMore: boolean;
   /** Custom element to display while loading more content (defaults to Spinner) */
   loadingMoreElement?: React.ReactNode;
-  /** Whether to show a "Load more" button instead of automatic infinite scroll */
+  /**
+   * Whether to show a "Load more" button instead of automatic infinite scroll
+   * @default true
+   */
   displayLoadMore?: boolean;
   /** Function called when more content should be loaded */
   onLoadMore: (() => void) | (() => Promise<void>);
   /** Custom button element or render function for the load more button */
   loadMoreButton?: React.ReactNode | ((props: { loadMore: () => void }) => React.ReactNode);
   /** Custom wrapper component for the content area */
-  ContentWrapper?: React.FC<React.PropsWithChildren>;
+  ContentWrapper?: typeof DefaultContentWrapper;
   /** Additional props passed to the intersection observer element */
   intersectionElementProps?: React.ComponentPropsWithoutRef<"div">;
+  /** Mode of the infinite scroll */
   mode?: "infinite" | "enable-once" | "pagination";
+}
+
+interface InfiniteScrollStatus {
+  /** Whether the infinite scroll is enabled */
+  infiniteScrollEnabled: boolean;
+  /** Whether the intersection observer is intersecting */
+  isIntersecting: boolean;
+  /** Whether the infinite scroll is idle */
+  isIdle: boolean;
 }
 
 export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProps>> = ({
@@ -49,26 +63,38 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
   loadingMoreElement,
   onLoadMore,
   loadMoreButton = "Load more",
-  ContentWrapper = defaultContentWrapper,
+  ContentWrapper = DefaultContentWrapper,
   intersectionElementProps,
   mode = loadMoreButton ? "enable-once" : "infinite",
 }) => {
+  // Intersection ref
   const intersectionRef = useRef<HTMLDivElement>(null);
 
-  const [infiniteScrollEnabled, setInfiniteScrollEnabled] = useState(mode === "infinite");
-  const [isIntersecting, setIsIntersecting] = useState(false);
+  // Status
+  const [{ infiniteScrollEnabled, isIntersecting, isIdle }, setStatus] = useReducer(
+    (prev: InfiniteScrollStatus, next: Partial<InfiniteScrollStatus>) => {
+      return { ...prev, ...next };
+    },
+    {
+      infiniteScrollEnabled: mode === "infinite",
+      isIntersecting: false,
+      isIdle: false,
+    },
+  );
 
+  // Has items left
   const hasItemsLeft = useMemo(
     () => (loaded === undefined && total === undefined) || (loaded ?? 0) < (total ?? 0),
     [loaded, total],
   );
 
+  // Load more button
   const LoadMoreButton = useMemo(() => {
-    if (!displayLoadMore) return null;
+    if (!displayLoadMore) return;
 
     const action = () => {
       if (mode === "enable-once") {
-        setInfiniteScrollEnabled(true);
+        setStatus({ infiniteScrollEnabled: true });
       } else {
         if (loading) return;
         void onLoadMore();
@@ -88,45 +114,14 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
     );
   }, [displayLoadMore, loadMoreButton, loading, mode, onLoadMore]);
 
-  const elements = useMemo<React.ReactNode[]>(() => {
-    const elements = [
-      hasItemsLeft && loading ? (loadingElement ?? <Skeleton />) : null,
-      children ? (
-        <ContentWrapper>
-          {direction === "top" && <div ref={intersectionRef} {...intersectionElementProps} />}
-          {children}
-          {direction === "bottom" && <div ref={intersectionRef} {...intersectionElementProps} />}
-        </ContentWrapper>
-      ) : null,
-      hasItemsLeft && loadingMore ? (loadingMoreElement ?? <Spinner />) : null,
-      displayLoadMore && !infiniteScrollEnabled && hasItemsLeft && !loading && !loadingMore
-        ? LoadMoreButton
-        : null,
-    ];
-
-    return direction === "bottom" ? elements : elements.reverse();
-  }, [
-    hasItemsLeft,
-    loading,
-    loadingElement,
-    children,
-    ContentWrapper,
-    intersectionRef,
-    loadingMore,
-    loadingMoreElement,
-    displayLoadMore,
-    infiniteScrollEnabled,
-    LoadMoreButton,
-    direction,
-    intersectionElementProps,
-  ]);
-
+  // Intersection observer
   useEffect(() => {
     if (!intersectionRef.current || !infiniteScrollEnabled || !children || !hasItemsLeft) return;
 
+    // eslint-disable-next-line compat/compat -- IntersectionObserver is not supported old browsers, but we target modern browsers
     const observer = new IntersectionObserver((entries) => {
       const isIntersecting = entries.some((entry) => entry.isIntersecting);
-      setIsIntersecting(isIntersecting);
+      setStatus({ isIntersecting });
     });
 
     observer.observe(intersectionRef.current);
@@ -136,12 +131,70 @@ export const InfiniteScroll: React.FC<React.PropsWithChildren<InfiniteScrollProp
     };
   }, [children, hasItemsLeft, infiniteScrollEnabled]);
 
+  // Load more
   useEffect(() => {
-    if (!isIntersecting || !infiniteScrollEnabled || loadingMore || loading || !hasItemsLeft)
+    if (
+      !isIntersecting ||
+      !infiniteScrollEnabled ||
+      loadingMore ||
+      loading ||
+      !hasItemsLeft ||
+      isIdle
+    )
       return;
 
-    void onLoadMore();
-  }, [hasItemsLeft, infiniteScrollEnabled, isIntersecting, loading, loadingMore, onLoadMore]);
+    async function load() {
+      setStatus({ isIdle: true });
+      try {
+        await onLoadMore();
+      } finally {
+        setStatus({ isIdle: false });
+      }
+    }
 
-  return <>{elements}</>;
+    // Load more
+    void load();
+  }, [
+    hasItemsLeft,
+    infiniteScrollEnabled,
+    isIntersecting,
+    loading,
+    loadingMore,
+    isIdle,
+    onLoadMore,
+  ]);
+
+  // Load more controls
+  const LoadMoreControls = useMemo(() => {
+    if (loadingMore) {
+      return loadingMoreElement ?? <Spinner />;
+    }
+
+    return displayLoadMore && !infiniteScrollEnabled && LoadMoreButton;
+  }, [LoadMoreButton, displayLoadMore, infiniteScrollEnabled, loadingMore, loadingMoreElement]);
+
+  // Loading element
+  if (hasItemsLeft && loading) {
+    return loadingElement ?? <Skeleton />;
+  }
+
+  return (
+    <ContentWrapper>
+      {direction === "top" && (
+        <>
+          {LoadMoreControls}
+          <div ref={intersectionRef} {...intersectionElementProps} />
+        </>
+      )}
+
+      {children}
+
+      {direction === "bottom" && (
+        <>
+          <div ref={intersectionRef} {...intersectionElementProps} />
+          {LoadMoreControls}
+        </>
+      )}
+    </ContentWrapper>
+  );
 };

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -8,7 +8,7 @@ export * from "./click-outside";
 
 export * from "./children-without-fragments";
 
-export { megeRefs, megeRefs as mergeRefs } from "./merge-refs";
+export { mergeRefs, mergeRefs as megeRefs } from "./merge-refs";
 
 export * from "./raf";
 

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -8,7 +8,7 @@ export * from "./click-outside";
 
 export * from "./children-without-fragments";
 
-export * from "./merge-refs";
+export { megeRefs, megeRefs as mergeRefs } from "./merge-refs";
 
 export * from "./raf";
 

--- a/packages/utils/react/src/merge-refs.ts
+++ b/packages/utils/react/src/merge-refs.ts
@@ -1,6 +1,6 @@
 import { type ForwardedRef, type RefObject, type RefCallback } from "react";
 
-export const megeRefs =
+export const mergeRefs =
   <T>(
     ...refs: Array<undefined | null | ForwardedRef<T> | RefObject<T | null> | RefCallback<T>>
   ): RefCallback<T> =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a modal loading API: new props to control loading states, custom loading/“load more” elements, total count, and a ContentWrapper; plus a mode prop with "infinite", "enable-once", and "pagination" behaviors.

- Refactor
  - Consolidated scroll/loading state into a single status-driven model and reorganized load controls and sentinel placement for more predictable behavior.

- Chores
  - Narrowed and clarified utility exports for ref handling (explicit export surface, alias retained for compatibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->