### PR TITLE
feat: select support for groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@abelflopes/react-ck",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@abelflopes/react-ck",
-      "version": "4.19.0",
+      "version": "4.20.0",
       "workspaces": [
         "packages/*/*"
       ],

--- a/packages/components/base/src/select/SelectGroup.tsx
+++ b/packages/components/base/src/select/SelectGroup.tsx
@@ -3,6 +3,7 @@ import { DISPLAY_NAME_ATTRIBUTE } from "@react-ck/react-utils";
 import { type SelectGroupProps } from "./types";
 import { Text } from "../text";
 import styles from "./styles/index.module.scss";
+import { useManagerContext } from "@react-ck/manager";
 
 /**
  * A group component for organizing Select options with a label.
@@ -29,9 +30,13 @@ const SelectGroup = ({
   name,
   children,
 }: Readonly<Omit<SelectGroupProps, "disabled">>): React.ReactElement => {
+  const { generateUniqueId } = useManagerContext();
+
+  const uniqueId = generateUniqueId();
+
   return (
-    <div role="group" aria-labelledby={name} className={styles.group}>
-      <div id={name} className={styles.group_name}>
+    <div role="group" aria-labelledby={uniqueId} className={styles.group}>
+      <div id={uniqueId} className={styles.group_name}>
         <Text margin="none" variation="small" skin={["bold", "soft"]}>
           {name}
         </Text>

--- a/packages/components/base/src/select/SelectGroup.tsx
+++ b/packages/components/base/src/select/SelectGroup.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { DISPLAY_NAME_ATTRIBUTE } from "@react-ck/react-utils";
+import { type SelectGroupProps } from "./types";
+import { Text } from "../text";
+import styles from "./styles/index.module.scss";
+
+/**
+ * A group component for organizing Select options with a label.
+ * Provides visual separation and organization for related options.
+ *
+ * @example
+ * ```tsx
+ * <Select>
+ *   <Select.Group name="Fruits">
+ *     <Select.Option value="apple">Apple</Select.Option>
+ *     <Select.Option value="banana">Banana</Select.Option>
+ *   </Select.Group>
+ *   <Select.Group name="Vegetables">
+ *     <Select.Option value="carrot">Carrot</Select.Option>
+ *     <Select.Option value="broccoli">Broccoli</Select.Option>
+ *   </Select.Group>
+ * </Select>
+ * ```
+ *
+ * @param props - Component props {@link SelectGroupProps}
+ * @returns React element
+ */
+const SelectGroup = ({
+  name,
+  children,
+}: Readonly<Omit<SelectGroupProps, "disabled">>): React.ReactElement => {
+  return (
+    <div role="group" aria-labelledby={name} className={styles.group}>
+      <div id={name} className={styles.group_name}>
+        <Text margin="none" variation="small" skin={["bold", "soft"]}>
+          {name}
+        </Text>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+SelectGroup[DISPLAY_NAME_ATTRIBUTE] = "SelectGroup";
+
+export { SelectGroup };

--- a/packages/components/base/src/select/styles/index.module.scss
+++ b/packages/components/base/src/select/styles/index.module.scss
@@ -4,11 +4,11 @@
 .root {
   @include form-field.form-field-input;
 
-  position: relative;
   display: inline-block;
   vertical-align: middle;
-  cursor: pointer;
+  position: relative;
   min-width: theme.get-spacing(10);
+  cursor: pointer;
 
   &.full_width {
     @include form-field.form-field-input-full-width;
@@ -19,20 +19,27 @@
 
 .value_slot {
   display: flex;
+  max-width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: theme.get-spacing(1);
+}
+
+.value_content {
+  display: flex;
   align-items: flex-start;
   justify-self: unset;
   flex-wrap: wrap;
   gap: theme.get-spacing(0.5);
-  max-width: 100%;
 }
 
 .display_value_item {
+  display: inline-block;
+  vertical-align: middle;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  display: inline-block;
-  max-width: 100%;
-  vertical-align: middle;
 }
 
 // When not inside form field, has own border, etc
@@ -64,12 +71,16 @@
 
 .native_element {
   position: absolute;
-  z-index: 1;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   opacity: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.loading {
   pointer-events: none;
 }
 
@@ -82,9 +93,23 @@
   It is used to ensure that the value slot is the same width as the native select element.
 */
 .size_setter {
-  position: absolute;
   display: block;
   flex-direction: column;
-  pointer-events: none;
+  position: absolute;
   opacity: 0;
+  pointer-events: none;
+}
+
+.group {
+  padding-top: theme.get-spacing(1);
+
+  &:not(:first-of-type) {
+    border-top: 1px solid theme.get-color(neutral-light-300);
+    margin-top: theme.get-spacing(1);
+  }
+}
+
+.group_name {
+  margin-inline: theme.get-spacing(1);
+  margin-bottom: theme.get-spacing(0.5);
 }

--- a/packages/components/base/src/select/types.ts
+++ b/packages/components/base/src/select/types.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { type DropdownProps } from "../dropdown";
 import { type InputProps } from "../input";
 import { type MenuItemProps } from "../menu";
@@ -69,6 +70,10 @@ export interface SelectProps
    * @default false
    */
   disabled?: boolean;
+  /** Select is loading
+   * @default false
+   */
+  loading?: boolean;
   /** Display value divider */
   displayValueDivider?: React.ReactNode;
   /** Whether the select should take the full width of the parent container */
@@ -101,6 +106,17 @@ export interface SelectOptionProps extends Omit<MenuItemProps, "skin"> {
 }
 
 /**
+ * Props interface for Select group components.
+ * Used to group related options together with a label.
+ */
+export interface SelectGroupProps {
+  /** Name/label for the group */
+  name: string;
+  /** Wrapper for select options */
+  children?: React.ReactNode;
+}
+
+/**
  * Internal type for processing select children data.
  * Used to normalize and handle different types of child elements.
  */
@@ -109,6 +125,8 @@ export type SelectChildrenData = {
   isSelectOption: boolean;
   /** Props passed to the SelectOption if applicable */
   selectOptionProps: SelectOptionProps | undefined;
+  /** Props passed to the SelectGroup if applicable */
+  selectGroupProps: SelectGroupProps | undefined;
   /** Processed value for the option */
   computedValue: string | undefined;
   /** Text content of the option */
@@ -117,4 +135,6 @@ export type SelectChildrenData = {
   element: React.ReactNode;
   /** Custom display value for selected state */
   displayValue: SelectOptionProps["displayValue"];
+  /** Group name if this is part of a group */
+  groupName?: string;
 };

--- a/packages/docs/stories/src/form-select.stories.tsx
+++ b/packages/docs/stories/src/form-select.stories.tsx
@@ -103,3 +103,60 @@ export const FullWidth: Story = {
     fullWidth: true,
   },
 };
+
+export const Loading: Story = {
+  args: {
+    ...args,
+    loading: true,
+    fullWidth: true,
+  },
+};
+
+export const WithGroups: Story = {
+  args: {
+    placeholder: "Select a food item",
+    children: (
+      <>
+        <Select.Group name="Fruits">
+          <Select.Option value="apple">Apple</Select.Option>
+          <Select.Option value="banana">Banana</Select.Option>
+          <Select.Option value="orange">Orange</Select.Option>
+          <Select.Option value="grape">Grape</Select.Option>
+        </Select.Group>
+        <Select.Group name="Vegetables">
+          <Select.Option value="carrot">Carrot</Select.Option>
+          <Select.Option value="broccoli">Broccoli</Select.Option>
+          <Select.Option value="spinach">Spinach</Select.Option>
+          <Select.Option value="tomato">Tomato</Select.Option>
+        </Select.Group>
+        <Select.Group name="Dairy">
+          <Select.Option value="milk">Milk</Select.Option>
+          <Select.Option value="cheese">Cheese</Select.Option>
+          <Select.Option value="yogurt">Yogurt</Select.Option>
+        </Select.Group>
+      </>
+    ),
+  },
+};
+
+export const WithGroupsAndSearch: Story = {
+  args: {
+    ...WithGroups.args,
+    search: {
+      placeholder: "Search food items",
+      emptyStateMessage: (value) => (
+        <>
+          No food items found for <b>&quot;{value}&quot;</b>
+        </>
+      ),
+    },
+  },
+};
+
+export const WithGroupsMultiple: Story = {
+  args: {
+    ...WithGroupsAndSearch.args,
+    multiple: true,
+    placeholder: "Select multiple food items",
+  },
+};


### PR DESCRIPTION
### Loading

<img width="329" height="155" alt="Screenshot 2025-10-01 at 5 02 15 PM" src="https://github.com/user-attachments/assets/a5936f92-7197-4e7c-a749-9430d397bc68" />

### Group

<img width="279" height="691" alt="Screenshot 2025-10-01 at 5 02 01 PM" src="https://github.com/user-attachments/assets/f6247ac2-eca8-4688-a10b-7625b80a1318" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Select.Group for grouped options with accessible group labels.
  - Added loading state to Select with spinner and chevron in the value area.
  - Enhanced filtering to show ungrouped options first, then grouped sections; works with search and multiple selection.

- Style
  - Updated Select visuals and layout for grouped sections and value display.

- Documentation
  - Added stories: Loading, WithGroups, WithGroupsAndSearch, WithGroupsMultiple.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->